### PR TITLE
Update ARP.cs

### DIFF
--- a/SharpPcap/ARP.cs
+++ b/SharpPcap/ARP.cs
@@ -138,8 +138,10 @@ namespace SharpPcap
             String arpFilter = "arp and ether dst " + localMAC.ToString();
 
             //open the device with 20ms timeout
-            _device.Open(DeviceMode.Promiscuous, 20);
-
+            if (!_device.Opened)
+            {
+                _device.Open(DeviceMode.Promiscuous, 20);
+            }
             //set the filter
             _device.Filter = arpFilter;
 
@@ -185,9 +187,6 @@ namespace SharpPcap
                     break;
                 }
             }
-
-            // free the device
-            _device.Close();
 
             // the timeout happened
             if(DateTime.Now >= timeoutDateTime)


### PR DESCRIPTION
If two concurrent arp request was send(interval < 20ms), when the first arp reply arrived, the device was closed and the second reply can not be received. So I think it better the keep the device open.